### PR TITLE
0.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /.output
 /PSModules
 /.vscode
+/PagerDutyAutomation/*.md
+/PagerDutyAutomation/LICENSE
+/PagerDutyAutomation/NOTICE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # PagerDutyAutomation Changelog
 
+## 0.1.2 (2023-01-11)
+
+* Fixed: Invoke-PDRestMethod fails to write a proper error when the PagerDuty API doesn't return an error object.
+
 ## 0.1.1 (2021-05-04)
 
 * Fixed: Invoke-PDRestMethod's default limit value (10000) fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+
+# PagerDutyAutomation Changelog
+
+## 0.1.1 (2021-05-04)
+
+* Fixed: Invoke-PDRestMethod's default limit value (10000) fails.
+
+## 0.1.0 (2020-12-10)
+
+* Created New-PDSession function for holding session information.
+* Created Invoke-PDRestMethod function for calling PagerDuty API endpoints.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+PagerDutyAutomation
+
+Copyright 2023 WebMD Health Services
+
+This product includes software developed at WebMD Health Services (https://www.webmdhealthservices.com/).

--- a/PagerDutyAutomation/Functions/Invoke-PDRestMethod.ps1
+++ b/PagerDutyAutomation/Functions/Invoke-PDRestMethod.ps1
@@ -7,15 +7,15 @@ function Invoke-PDRestMethod
 
     .DESCRIPTION
     The `Invoke-PDRestMethod` calls an endpoint on the PagerDuty API. Pass the session to use to the `Session` parameter
-    (create a session with the `New-PDSession` function). Pass the path to the endpoint to the `Path` parameter. 
-    
+    (create a session with the `New-PDSession` function). Pass the path to the endpoint to the `Path` parameter.
+
     If the endpoint returns paged results, `Invoke-PDRestMethod` will return an object for the first page of results.
     The return object will have these properties (see https://developer.pagerduty.com/docs/rest-api-v2/pagination/):
-    
+
     * `limit`, which is the number of objects returned.
     * `offset`, which is the index of the first item in the results across all pages.
     * `more`, which is `$true` if there are more results and `$false` otherwise.
-    * `total`, which is `$null` by default. If you want to know the total number of records across all pages, use the 
+    * `total`, which is `$null` by default. If you want to know the total number of records across all pages, use the
       `IncludeTotal` parameter, and then this property will be the total number of objects.
 
     Use the `Offset` parameter to control the start index of the records to return. Use the `Count` parameter to control
@@ -23,8 +23,8 @@ function Invoke-PDRestMethod
 
     If you don't want to paginate, use the `All` parameter to return all records.
 
-    If you want to find a specific item, you can pass a script block expression to the `First` parameter. 
-    `Invoke-PDRestMethod` will return the first object that returns `$true` when passed through that filter using 
+    If you want to find a specific item, you can pass a script block expression to the `First` parameter.
+    `Invoke-PDRestMethod` will return the first object that returns `$true` when passed through that filter using
     `Where-Object`. `Invoke-PDRestMethod` will automatically page through results until it finds an item and stops
     making requests once the object is found.
 
@@ -32,7 +32,7 @@ function Invoke-PDRestMethod
     parameter. `Invoke-PDRestMethod` will page through all results and return objects that return `$true` when passed
     to the script block using the `Where-Object` cmdlet.
 
-    If you have the full URL to an item (usually from the `self` property on an object returned by an endpoint), you 
+    If you have the full URL to an item (usually from the `self` property on an object returned by an endpoint), you
     can pass that to the `Uri` parameter.
 
     If you're calling an endpoint that receives a JSON body, pass the JSON to the `Body` parameter. You can also pass in
@@ -61,15 +61,15 @@ function Invoke-PDRestMethod
 
     .EXAMPLE
     $page = Invoke-PDRestMethod -Session $session -path 'services' -IncludeTotal
-    
+
     Demonstrates how to use the `IncludeTotal` parameter to include the total number of results across all pages in the
     return object.
 
     .EXAMPLE
     Invoke-PDRestMethod -Session $session -Path 'services' -First { $_.name -eq 'My Service' }
 
-    Demonstrates how to use the `First` parameter to return the first item that gets selected by a script block. The 
-    script block is passed to `Where-Object` to select the object to return. Once an object is found, no further 
+    Demonstrates how to use the `First` parameter to return the first item that gets selected by a script block. The
+    script block is passed to `Where-Object` to select the object to return. Once an object is found, no further
     requests are made to PagerDuty.
 
     .EXAMPLE
@@ -166,7 +166,7 @@ function Invoke-PDRestMethod
 
             $results =
                 $page.$resultPropertyName |
-                Where-Object { 
+                Where-Object {
                     if( $First )
                     {
                         $_ | Where-Object $First
@@ -228,7 +228,7 @@ function Invoke-PDRestMethod
         {
             $queryString = "?$($queryString -join '&')"
         }
-        $url = "$($Session.Url)/$($Path.TrimStart('/'))$($queryString)" 
+        $url = "$($Session.Url)/$($Path.TrimStart('/'))$($queryString)"
     }
 
     $conditionalParams = @{}
@@ -257,7 +257,7 @@ function Invoke-PDRestMethod
     catch
     {
         $pderror = $_.ErrorDetails | ConvertFrom-Json
-        
+
         $response = $_.Exception.Response
         $httpStatusDesc = & {
             if( $response | Get-Member -Name 'ReasonPhrase' )
@@ -268,13 +268,33 @@ function Invoke-PDRestMethod
             return $response.StatusDescription
         }
         $httpStatusCode = $_.Exception.Response.StatusCode
-        $msg = "Request to $($url) failed with HTTP error ""$($httpStatusDesc)"" ($([int]$httpStatusCode)) and " +
-               "PagerDuty error ""$($pderror.error.message)"" ($($pderror.error.code))."
-        
-        if( $pderror.error | Get-Member -Name 'errors' )
+
+        $msg = "Request to $($url) failed with HTTP error ""$($httpStatusDesc)"" ($([int]$httpStatusCode))."
+
+        $pdErrMsg =
+            $pderror |
+            Select-Object -ExpandProperty 'error' -ErrorAction Ignore |
+            Select-Object -ExpandProperty 'message' -ErrorAction Ignore
+
+        $pdErrCode =
+            $pderror |
+            Select-Object -ExpandProperty 'error' -ErrorAction Ignore |
+            Select-Object -ExpandProperty 'code' -ErrorAction Ignore
+
+        if ($pdErrMsg)
         {
-            $msg = "$($msg) $($pdError.error.errors -join '. ')."
+            $msg = "$($msg) PagerDuty error ""$($pdErrMsg)"" ($($pdErrCode)))."
+
+            $pdErrList =
+                $pderror.error |
+                Select-Object -ExpandProperty 'errors' -ErrorAction Ignore
+
+            if ($pdErrList)
+            {
+                $msg = "$($msg) $($pdErrList -join '. ')."
+            }
         }
+
         Write-Error -Message $msg -ErrorAction $ErrorActionPreference
         return
     }

--- a/PagerDutyAutomation/PagerDutyAutomation.psd1
+++ b/PagerDutyAutomation/PagerDutyAutomation.psd1
@@ -108,16 +108,8 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = @'
-# 0.1.1
+            ReleaseNotes = 'https://github.com/webmd-health-services/PagerDutyAutomation/blob/master/CHANGELOG.md'
 
-* Fixed: Invoke-PDRestMethod's default limit value (10000) fails. 
-
-# 0.1.0
-
-* Created `New-PDSession` function for holding session information.
-* Created `Invoke-PDRestMethod` function for calling PagerDuty API endpoints.
-'@
         } # End of PSData hashtable
 
     } # End of PrivateData hashtable

--- a/PagerDutyAutomation/PagerDutyAutomation.psd1
+++ b/PagerDutyAutomation/PagerDutyAutomation.psd1
@@ -10,7 +10,7 @@
     RootModule = 'PagerDutyAutomation.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.1.1'
+    ModuleVersion = '0.1.2'
 
     # ID used to uniquely identify this module
     GUID = '551979DA-2622-443C-BB85-1D510601FC76'

--- a/Tests/Invoke-PDRestMethod.Tests.ps1
+++ b/Tests/Invoke-PDRestMethod.Tests.ps1
@@ -46,7 +46,7 @@ Describe 'Invoke-PDRestMethod.when requesting total objects in a paged endpoint'
 Describe 'Invoke-PDRestMethod.when requesting a single object' {
     It 'should return just that object' {
         $lastService = Invoke-PDRestMethod -Session $session -Path 'services' -All | Select-Object -Last 1
-        
+
         $result = Invoke-PDRestMethod -Session $session -Path 'services' -First { $_.id -eq $lastService.id }
         $result | Should -Not -BeNullOrEmpty
         $result.id | Should -Be $lastService.id
@@ -71,12 +71,12 @@ Describe 'Invoke-PDRestMethod.when filtering results' {
 Describe 'Invoke-PDRestMethod.when api throws an error' {
     It 'should write error' {
         { Invoke-PDRestMethod -Session $session -Path 'services/fubar/fubar' -ErrorAction Stop } |
-            Should -Throw 'failed with HTTP error "Not Found" (404) and PagerDuty error "Not Found" (2100)'
+            Should -Throw 'failed with HTTP error "Not Found" (404). PagerDuty error "Not Found" (2100)).'
     }
 }
 
 Describe 'Invoke-PDRestMethod.when api throws an error and ignoring errors' {
-    It 'should write no error' { 
+    It 'should write no error' {
         $Global:Error.Clear()
         { Invoke-PDRestMethod -Session $session -Path 'services/fubar/fubar' -ErrorAction Ignore } | Should -Not -Throw
         $Global:Error | Where-Object { $_ -like 'failed with HTTP error * and PagerDuty error' } | Should -BeNullOrEmpty
@@ -108,7 +108,7 @@ Describe 'Invoke-PDRestMethod.when user passes string for body' {
         Invoke-PDRestMethod -Session $session -Path 'some/path' -Body $expectedBody
         Assert-MockCalled -CommandName 'Invoke-RestMethod' `
                           -ModuleName 'PagerDutyAutomation' `
-                          -ParameterFilter { 
+                          -ParameterFilter {
                               $Body | Should -Be $expectedBody
                               return $true
                           }
@@ -126,8 +126,8 @@ Describe 'Invoke-PDRestMethod.when user passes object for body' {
         Invoke-PDRestMethod -Session $session -Path 'some/path' -Body $bodyObject
         Assert-MockCalled -CommandName 'Invoke-RestMethod' `
                           -ModuleName 'PagerDutyAutomation' `
-                          -ParameterFilter { 
-                              $Body | Should -Be ($bodyObject | ConvertTo-Json) 
+                          -ParameterFilter {
+                              $Body | Should -Be ($bodyObject | ConvertTo-Json)
                               return $true
                           }
     }

--- a/whiskey.yml
+++ b/whiskey.yml
@@ -15,9 +15,16 @@ Build:
     TextSeparator: "$(NewLine)$(NewLine)"
 - Pester4:
     Path: Tests\*.Tests.ps1
+- CopyFile:
+    Path:
+    - CHANGELOG.md
+    - LICENSE
+    - NOTICE
+    - README.md
+    DestinationDirectory: PagerDutyAutomation
 - Zip:
     ArchivePath: .output\PagerDutyAutomation.zip
-    Path: 
+    Path:
     - PagerDutyAutomation
 
 Publish:


### PR DESCRIPTION
* Fixed: Invoke-PDRestMethod fails to write a proper error when the PagerDuty API doesn't return an error object.